### PR TITLE
ci(dependabot): configure ignore rules for ESLint ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,15 @@ updates:
         update-types:
           - 'version-update:semver-major'
           - 'version-update:semver-minor'
+      - dependency-name: '@eslint/*'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'eslint*'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'globals'
+        update-types:
+          - 'version-update:semver-major'
     commit-message:
       prefix: 'build'
       include: 'scope'


### PR DESCRIPTION
Lock ESLint major updates to v9 because `eslint-plugin-import` (and its webpack resolver) currently does not support ESLint v10, which causes `ERESOLVE` peer dependency failures during `npm ci`.

Upstream tracker: https://github.com/import-js/eslint-plugin-import/issues/3278